### PR TITLE
penetrable segment order

### DIFF
--- a/vmod/source/regsill.py
+++ b/vmod/source/regsill.py
@@ -38,93 +38,62 @@ class Regsill(Source):
         self.parameters=("xcen","ycen","depth","length","width","strike","dip","slips/openings")
         
     def rotate_xyz(self,xcen,ycen,depth,length,width,strike,dip):
-        cx=xcen
-        cy=ycen
-        cz=-depth
-        wp=width*np.cos(np.radians(dip))
-        wr=width*np.sin(np.radians(dip))
-        l=length
-        phi=strike
-        x1 = cx + wp/2 * np.cos(np.radians(phi)) - l/2 * np.sin(np.radians(phi))
-        y1 = cy + wp/2 * np.sin(np.radians(phi)) + l/2 * np.cos(np.radians(phi))
-        z1 = cz - wr/2
-        x2 = cx - wp/2 * np.cos(np.radians(phi)) - l/2 * np.sin(np.radians(phi))
-        y2 = cy - wp/2 * np.sin(np.radians(phi)) + l/2 * np.cos(np.radians(phi))
-        z2 = cz + wr/2
-        x3 = cx - wp/2 * np.cos(np.radians(phi)) + l/2 * np.sin(np.radians(phi))
-        y3 = cy - wp/2 * np.sin(np.radians(phi)) - l/2 * np.cos(np.radians(phi))
-        z3 = cz + wr/2
-        x4 = cx + wp/2 * np.cos(np.radians(phi)) + l/2 * np.sin(np.radians(phi))
-        y4 = cy + wp/2 * np.sin(np.radians(phi)) - l/2 * np.cos(np.radians(phi))
-        z4 = cz - wr/2
+    # this function calculates the coordinates of four corners of a triangle
+    # (in this RegSill class, the triangle represents a fault plane)
+    # inputs: parameters defining the triangle
+    #   - xcen, ycen, depth [m]: location of fault center
+    #   - strike, dip [deg]: fault orientation parameters
+    #   - length [m]: fault length (along strike line)
+    #   - width [m]: fault width (along dip line)
+    # output: coordinates of top-left, bottom-left, bottom=right, and top-right corners
+
+        zcen  = -depth
+        srad  = math.radians(strike)
+        drad  = math.radians(dip)
         
-        return [x1,x2,x3,x4],[y1,y2,y3,y4],[z1,z2,z3,z4]
+        # top-left corner
+        x1 = xcen - length/2.0*math.sin(srad) - width/2.0*math.cos(drad)*math.cos(srad)
+        y1 = ycen - length/2.0*math.cos(srad) + width/2.0*math.cos(drad)*math.sin(srad)
+        z1 = zcen + width/2.0*math.sin(drad)
+        
+        # bottom-left corner
+        x2 = xcen - length/2.0*math.sin(srad) + width/2.0*math.cos(drad)*math.cos(srad)
+        y2 = ycen - length/2.0*math.cos(srad) - width/2.0*math.cos(drad)*math.sin(srad)
+        z2 = zcen - width/2.0*math.sin(drad)
+        
+        # bottom-right corner
+        x3 = xcen + length/2.0*math.sin(srad) + width/2.0*math.cos(drad)*math.cos(srad)
+        y3 = ycen + length/2.0*math.cos(srad) - width/2.0*math.cos(drad)*math.sin(srad)
+        z3 = zcen - width/2.0*math.sin(drad)
+        
+        # top-right corner
+        x4 = xcen + length/2.0*math.sin(srad) - width/2.0*math.cos(drad)*math.cos(srad)
+        y4 = ycen + length/2.0*math.cos(srad) + width/2.0*math.cos(drad)*math.sin(srad)
+        z4 = zcen + width/2.0*math.sin(drad)
+        
+        return [x1,y1,z1],[x2,y2,z2],[x3,y3,z3],[x4,y4,z4]
         
     def get_centers(self,xcen,ycen,depth,length,width,strike,dip):
-        xc=xcen
-        yc=ycen
-        zc=-depth
-        ln=self.ln
-        wn=self.wn
-        lslice=length/ln
-        wslice=width/wn
-        fwc=xcen-width/2+width/(2*wn)
-        flc=ycen-length/2+length/(2*ln)
-        #print(fwc,flc)
-        xcs,ycs,zcs=[],[],[]
-        if wn%2==0:
-            wi=wn/2
-        else:
-            wi=(wn-1)/2
-            
-        if ln%2==0:
-            li=ln/2
-        else:
-            li=(ln-1)/2
-            
-        for i in range(int(wi)):
-            wfake=2*np.abs(fwc-xcen+float(i)*wslice)
-            for j in range(int(li)):
-                lfake=2*np.abs(flc-ycen+float(j)*lslice)
-                xs,ys,zs=self.rotate_xyz(xcen,ycen,depth,lfake,wfake,strike,dip)
-                for x in xs:
-                    xcs.append(x)
-                for y in ys:
-                    ycs.append(y)
-                for z in zs:
-                    zcs.append(z)
-        print('Puntos 1',len(xcs),wn%2,ln%2)
-        if not ln%2==0:
-            for j in range(int(li)):
-                wfake=0
-                lfake=2*np.abs(flc-ycen+float(j)*lslice)
-                xs,ys,zs=self.rotate_xyz(xcen,ycen,depth,lfake,wfake,strike,dip)
-                for x in xs[1:3]:
-                    xcs.append(x)
-                for y in ys[1:3]:
-                    ycs.append(y)
-                for z in zs[1:3]:
-                    zcs.append(z)
-        print('Puntos 2',len(xcs))
-        if not wn%2==0:
-            for i in range(int(wi)):
-                wfake=2*np.abs(fwc-xcen+float(i)*wslice)
-                lfake=0
-                xs,ys,zs=self.rotate_xyz(xcen,ycen,depth,lfake,wfake,strike,dip)
-                for x in xs[0:2]:
-                    xcs.append(x)
-                for y in ys[0:2]:
-                    ycs.append(y)
-                for z in zs[0:2]:
-                    zcs.append(z)
-        print('Puntos 3',len(xcs))
-        if (not wn%2==0) and (not ln%2==0):
-            print('Ninguno')
-            xcs.append(xcen)
-            ycs.append(ycen)
-            zcs.append(-depth)
-        print('Puntos 4',len(xcs))
-        return xcs,ycs,zcs
+    # this function calculates the center coordinates of all fault patches
+    # the order of patches to be calculated is from left to right along length, from top to bottom along width
+    # for example, for a nl=3,nw=2 fault, the order of calculation is
+    #     [1] [2] [3]
+    #     [4] [5] [6]
+    #
+    # calculation is based on the following formula
+    # x_{i,j} = x_{top-left} + i/nl*( x_{top-right} - x_{top-left} ) + j/nw*( x_{bottom-left} - x_{top-left} )
+    
+        ln = self.ln
+        wn = self.wn
+        [x1,y1,z1],[x2,y2,z2],[x3,y3,z3],[x4,y4,z4] = self.rotate_xyz(xcen,ycen,depth,length,width,strike,dip)
+        
+        xcenters,ycenters,zcenters=[],[],[]
+        for j in range(wn):
+            for i in range(ln):
+                xcenters.append( x1 + (x4-x1)/ln*(i + 0.5) + ((x2-x1)/wn)*(j+0.5) )
+                ycenters.append( y1 + (y4-y1)/ln*(i + 0.5) + ((y2-y1)/wn)*(j+0.5) )
+                zcenters.append( z1 + (z4-z1)/ln*(i + 0.5) + ((z2-z1)/wn)*(j+0.5) )
+        return xcenters,ycenters,zcenters
     
     def get_laplacian(self,xcen,ycen,depth,length,width,strike,dip,ln,wn):
         xcs,ycs,zcs=self.get_centers(xcen,ycen,depth,length,width,strike,dip,ln,wn)
@@ -239,36 +208,47 @@ class Regsill(Source):
         return ux,uy,uz
         
     def plot_patches(self,length,width,ops):
+    # this function plot the 3D fault into a 2D plane
+    # input parameter ops is a 1D array for openings. its order is described in self.get_centers()
         import matplotlib
         import matplotlib.pyplot as plt
-        import numpy as np
         
-        ln=self.ln
-        wn=self.wn
+        ln = self.ln
+        wn = self.wn
 
         ok1 = Okada(self.data)
         ok1.set_type('open')
-        xs,ys,zs=self.get_centers(0,0,0,length,width,0,0)
+        # lay the fault flat for plotting, length is on east-west direction, and width in north-south
+        xs,ys,zs = self.get_centers(0,0,0,length,width,90,0)
 
-        patches=[]
-        fig, ax = plt.subplots()
+        patches = []
         for i in range(len(xs)):
+            # rect takes the bottom-left coordinates and length/width for a patch 
             rect = matplotlib.patches.Rectangle((xs[i]-length/(2*ln),ys[i]-width/(2*wn)), length/ln, width/wn)
             patches.append(rect)
-
-        # values as numpy array
         values = ops
+        
+        # viridis for all-positive fault, bwr for bi-symbol opennings
+        if (values.min()*values.max())<0:
+            cmap  = 'bwr'
+            maxop = np.maximum( np.abs(values.min()) , values.max() )
+            norm  = plt.Normalize(-maxop, maxop)
+        else:
+            cmap = 'viridis'
+            norm = plt.Normalize(values.min(), values.max())
 
-        # define the norm 
-        norm = plt.Normalize(values.min(), values.max())
-        coll = matplotlib.collections.PatchCollection(patches, cmap='viridis',
+        coll = matplotlib.collections.PatchCollection(patches, cmap=cmap,
                                                       norm=norm, match_original = True)
-
         coll.set_array(values)
-        polys = ax.add_collection(coll)
-        fig.colorbar(polys, label='Opening(m)')
-
-        plt.xlim(-width/2,width/2)
-        plt.ylim(-length/2,length/2)
+        
+        fig, ax = plt.subplots()
+        polys   = ax.add_collection(coll)
+        cbar    = fig.colorbar(polys, label='Opening (m)', orientation='horizontal')
+        
+        plt.gca().set_aspect('equal')
+        plt.xlim(-length/2,length/2)
+        plt.ylim(-width/2,width/2)
 
         plt.show()
+        print( 'plotting length (m): '+str(length) )
+        print( 'plotting width (m):'+str(width) )


### PR DESCRIPTION
This PR is not about the implementation of regularization within Bayesian inversion, which we just talked about today. It is about some previous modification on defining fault segments.

The only file that was changes is `vmod/source/regsill.py`, where `rotate_xyz` and `plot_patches` were modified, and `get_centers` were re-designed. The most advantage of this version is that the order of segments being calculated becomes explicit, making it much easier to understand and manually control the openings. 

The new strategy for calculating the patch locations is:
x_{i,j} = x_{top-left} + i/nl*( x_{top-right} - x_{top-left} ) + j/nw*( x_{bottom-left} - x_{top-left} )
Please check the comments in the file for detail.

